### PR TITLE
Add fields for admin exports

### DIFF
--- a/app/jobs/decidim/export_job.rb
+++ b/app/jobs/decidim/export_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ExportJob < ApplicationJob
+    queue_as :default
+
+    def perform(user, component, name, format)
+      export_manifest = component.manifest.export_manifests.find do |manifest|
+        manifest.name == name.to_sym
+      end
+
+      collection = export_manifest.collection.call(component, user)
+      serializer = export_manifest.serializer
+
+      export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer, user.admin?).export
+
+      ExportMailer.export(user, name, export_data).deliver_now
+    end
+  end
+end

--- a/app/serializers/decidim/exporters/serializer.rb
+++ b/app/serializers/decidim/exporters/serializer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Exporters
+    # This is an abstract class with a very naive default implementation
+    # for the exporters to use. It can also serve as a superclass of your
+    # own implementation.
+    #
+    # It is used to be run against each element of an exportable collection
+    # in order to extract relevant fields. Every export should specify their
+    # own serializer or this default will be used.
+    class Serializer
+      attr_reader :resource
+
+      # Initializes the serializer with a resource.
+      #
+      # resource - The Object to serialize.
+      # private_scope - Boolean to differentiate open data export and administrator export. By default scope is public.
+      def initialize(resource, private_scope = false)
+        @resource = resource
+        @private_scope = private_scope
+      end
+
+      # Public: Returns a serialized view of the provided resource.
+      #
+      # Returns a nested Hash with the fields.
+      def serialize
+        @resource.to_h.merge options_merge(admin_extra_fields)
+      end
+
+      private
+
+      # Private: Returns a Hash with additional fields to export if the export is done by administrator
+      #
+      # Returns a empty hash or Hash with some other fields
+      def options_merge(options = {})
+        return {} unless options.is_a?(Hash) && @private_scope
+
+        options
+      end
+
+      # Private: Returns a Hash with additional fields that administrator want to see in export
+      #
+      # Returns a Hash
+      def admin_extra_fields
+        {}
+      end
+    end
+  end
+end

--- a/app/serializers/decidim/meetings/data_portability_registration_serializer.rb
+++ b/app/serializers/decidim/meetings/data_portability_registration_serializer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class DataPortabilityRegistrationSerializer < Decidim::Exporters::Serializer
+      # Serializes a registration for data portability
+      def serialize
+        {
+            id: resource.id,
+            code: resource.code,
+            user: {
+                name: resource.user.name,
+                email: resource.user.email
+            },
+            meeting: {
+                title: resource.meeting.title,
+                description: resource.meeting.description,
+                start_time: resource.meeting.start_time,
+                end_time: resource.meeting.end_time,
+                address: resource.meeting.address,
+                location: resource.meeting.location,
+                location_hints: resource.meeting.location_hints,
+                reference: resource.meeting.reference,
+                attendees_count: resource.meeting.attendees_count,
+                attending_organizations: resource.meeting.attending_organizations,
+                closed_at: resource.meeting.closed_at,
+                closing_report: resource.meeting.closing_report
+            }
+        }.merge(options_merge(admin_extra_fields))
+      end
+
+      private
+
+      # Private: Returns a Hash with additional fields that administrator want to see in export
+      #
+      # Returns a Hash
+      def admin_extra_fields
+        {
+            extended_data: {
+                age_slice: extended_data_key(resource.user, "age_slice"),
+                group_membership: extended_data_key(resource.user, "group_membership"),
+                question_racialized: extended_data_key(resource.user, "question_racialized"),
+                question_gender: extended_data_key(resource.user, "question_gender"),
+                question_sexual_orientation: extended_data_key(resource.user, "question_sexual_orientation"),
+                question_disability: extended_data_key(resource.user, "question_disability"),
+                question_social_context: extended_data_key(resource.user, "question_social_context")
+            }
+        }
+      end
+
+      def extended_data_key(user, key)
+        return "" if user.try(:extended_data).blank?
+        return "" if user[:extended_data].fetch(key, nil).blank?
+
+        user[:extended_data][key]
+      end
+    end
+  end
+end

--- a/app/serializers/decidim/meetings/registration_serializer.rb
+++ b/app/serializers/decidim/meetings/registration_serializer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class RegistrationSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+      # Serializes a registration
+      def serialize
+        {
+            id: resource.id,
+            code: resource.code,
+            user: {
+                name: resource.user.name,
+                email: resource.user.email,
+                user_group: resource.user_group&.name || ""
+            },
+            registration_form_answers: serialize_answers
+        }.merge(options_merge(admin_extra_fields))
+      end
+
+      private
+
+      def serialize_answers
+        questions = resource.meeting.questionnaire.questions
+        answers = resource.meeting.questionnaire.answers.where(user: resource.user)
+        questions.each_with_index.inject({}) do |serialized, (question, idx)|
+          answer = answers.find_by(question: question)
+          serialized.update("#{idx + 1}. #{translated_attribute(question.body)}" => normalize_body(answer))
+        end
+      end
+
+      def normalize_body(answer)
+        return "" unless answer
+
+        answer.body || answer.choices.pluck(:body)
+      end
+
+      # Private: Returns a Hash with additional fields that administrator want to see in export
+      #
+      # Returns a Hash
+      def admin_extra_fields
+        {
+            extended_data: {
+                age_slice: extended_data_key(resource.user, "age_slice"),
+                group_membership: extended_data_key(resource.user, "group_membership"),
+                question_racialized: extended_data_key(resource.user, "question_racialized"),
+                question_gender: extended_data_key(resource.user, "question_gender"),
+                question_sexual_orientation: extended_data_key(resource.user, "question_sexual_orientation"),
+                question_disability: extended_data_key(resource.user, "question_disability"),
+                question_social_context: extended_data_key(resource.user, "question_social_context")
+            }
+        }
+      end
+
+      def extended_data_key(user, key)
+        return "" if user.try(:extended_data).blank?
+        return "" if user[:extended_data].fetch(key, nil).blank?
+
+        user[:extended_data][key]
+      end
+    end
+  end
+end

--- a/lib/decidim/accountability/result_serializer.rb
+++ b/lib/decidim/accountability/result_serializer.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    # This class serializes a Result so can be exported to CSV, JSON or other
+    # formats.
+    class ResultSerializer < Decidim::Exporters::Serializer
+      include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
+
+      # Public: Initializes the serializer with a result.
+      def initialize(result, private_scope = false)
+        @result = result
+        @private_scope = private_scope
+      end
+
+      # Public: Exports a hash with the serialized data for this result.
+      def serialize
+        {
+            id: result.id,
+            category: {
+                id: result.category.try(:id),
+                name: result.category.try(:name) || empty_translatable
+            },
+            scope: {
+                id: result.scope.try(:id),
+                name: result.scope.try(:name) || empty_translatable
+            },
+            parent: {
+                id: result.parent.try(:id)
+            },
+            title: result.title,
+            description: result.description,
+            start_date: result.start_date,
+            end_date: result.end_date,
+            status: {
+                id: result.status.try(:id),
+                key: result.status.try(:key),
+                name: result.status.try(:name) || empty_translatable
+            },
+            progress: result.progress,
+            created_at: result.created_at,
+            url: url,
+            component: { id: component.id },
+            proposal_urls: proposals
+        }
+      end
+
+      private
+
+      attr_reader :result
+
+      def component
+        result.component
+      end
+
+      def proposals
+        result.linked_resources(:proposals, "included_proposals").map do |proposal|
+          Decidim::ResourceLocatorPresenter.new(proposal).url
+        end
+      end
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(result).url
+      end
+    end
+  end
+end

--- a/lib/decidim/comments/comment_serializer.rb
+++ b/lib/decidim/comments/comment_serializer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    class CommentSerializer < Decidim::Exporters::Serializer
+      include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
+
+      # Serializes a comment
+      def serialize
+        {
+            id: resource.id,
+            created_at: resource.created_at,
+            body: resource.body,
+            author: {
+                id: resource.author.id,
+                name: resource.author.name
+            },
+            alignment: resource.alignment,
+            depth: resource.depth,
+            user_group: {
+                id: resource.user_group.try(:id),
+                name: resource.user_group.try(:name) || empty_translatable
+            },
+            commentable_id: resource.decidim_commentable_id,
+            commentable_type: resource.decidim_commentable_type,
+            root_commentable_url: root_commentable_url
+        }.merge(options_merge(admin_extra_fields))
+      end
+
+      private
+
+      def root_commentable_url
+        @root_commentable_url ||= Decidim::ResourceLocatorPresenter.new(resource.root_commentable).url
+      end
+
+      # Private: Returns a Hash with additional fields that administrator want to see in export
+      #
+      # Returns a Hash
+      def admin_extra_fields
+        {
+            extended_data: {
+                age_slice: extended_data_key(resource.author, "age_slice"),
+                group_membership: extended_data_key(resource.author, "group_membership"),
+                question_racialized: extended_data_key(resource.author, "question_racialized"),
+                question_gender: extended_data_key(resource.author, "question_gender"),
+                question_sexual_orientation: extended_data_key(resource.author, "question_sexual_orientation"),
+                question_disability: extended_data_key(resource.author, "question_disability"),
+                question_social_context: extended_data_key(resource.author, "question_social_context")
+            }
+        }
+      end
+
+      def extended_data_key(user, key)
+        return "" if user.try(:extended_data).blank?
+        return "" if user[:extended_data].fetch(key, nil).blank?
+
+        user[:extended_data][key]
+      end
+    end
+  end
+end

--- a/lib/decidim/dev/test/rspec_support/component.rb
+++ b/lib/decidim/dev/test/rspec_support/component.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "decidim/component_validator"
+require "decidim/comments"
+
+module Decidim
+  class DummyResourceEvent < Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
+  end
+
+  module DummyResources
+    include ActiveSupport::Configurable
+
+    # Settings needed to compare emendations in Decidim::SimilarEmendations
+    config_accessor :similarity_threshold do
+      0.25
+    end
+    config_accessor :similarity_limit do
+      10
+    end
+
+    # Dummy engine to be able to test components.
+    class DummyEngine < Rails::Engine
+      engine_name "dummy"
+      isolate_namespace Decidim::DummyResources
+
+      routes do
+        root to: proc { [200, {}, ["DUMMY ENGINE"]] }
+
+        resources :dummy_resources do
+          get :foo, on: :member
+        end
+      end
+    end
+
+    class DummyAdminEngine < Rails::Engine
+      engine_name "dummy_admin"
+
+      routes do
+        root to: proc { [200, {}, ["DUMMY ADMIN ENGINE"]] }
+      end
+    end
+
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+    end
+
+    class DummyResource < ApplicationRecord
+      include HasComponent
+      include HasReference
+      include Resourceable
+      include Reportable
+      include Authorable
+      include HasCategory
+      include ScopableComponent
+      include Decidim::Comments::Commentable
+      include Followable
+      include Traceable
+      include Publicable
+      include Decidim::DataPortability
+      include Searchable
+      include Paddable
+      include Amendable
+      include Decidim::NewsletterParticipant
+      include Hashtaggable
+      include ::Decidim::Endorsable
+      include Decidim::HasAttachments
+
+      searchable_fields(
+          scope_id: { scope: :id },
+          participatory_space: { component: :participatory_space },
+          A: [:title],
+          D: [:address],
+          datetime: :published_at
+      )
+
+      amendable(
+          fields: [:title],
+          form: "Decidim::DummyResources::DummyResourceForm"
+      )
+
+      component_manifest_name "dummy"
+
+      def reported_content_url
+        ResourceLocatorPresenter.new(self).url
+      end
+
+      def allow_resource_permissions?
+        component.settings.resources_permissions_enabled
+      end
+
+      def self.user_collection(user)
+        where(decidim_author_id: user.id, decidim_author_type: "Decidim::User")
+      end
+
+      def self.export_serializer
+        DummySerializer
+      end
+
+      def self.newsletter_participant_ids(component)
+        Decidim::DummyResources::DummyResource.where(component: component).joins(:component)
+            .where(decidim_author_type: Decidim::UserBaseEntity.name)
+            .where.not(author: nil)
+            .pluck(:decidim_author_id).flatten.compact.uniq
+      end
+    end
+
+    class CoauthorableDummyResource < ApplicationRecord
+      include ::Decidim::Coauthorable
+      include HasComponent
+    end
+
+    class OfficialAuthorPresenter
+      def name
+        self.class.name
+      end
+
+      def nickname
+        UserBaseEntity.nicknamize(name)
+      end
+
+      def deleted?
+        false
+      end
+
+      def respond_to_missing?
+        true
+      end
+
+      def method_missing(method, *args)
+        if method.to_s.ends_with?("?")
+          false
+        elsif [:avatar_url, :profile_path, :badge, :followers_count].include?(method)
+          ""
+        else
+          super
+        end
+      end
+    end
+  end
+end
+
+class DummySerializer
+  def initialize(id, private_scope = false)
+    @id = id
+    @private_scope = private_scope
+  end
+
+  def serialize
+    {
+        id: @id
+    }
+  end
+end
+
+Decidim.register_component(:dummy) do |component|
+  component.engine = Decidim::DummyResources::DummyEngine
+  component.admin_engine = Decidim::DummyResources::DummyAdminEngine
+  component.icon = "decidim/dummy.svg"
+
+  component.actions = %w(foo bar)
+
+  component.newsletter_participant_entities = ["Decidim::DummyResources::DummyResource"]
+
+  component.settings(:global) do |settings|
+    settings.attribute :comments_enabled, type: :boolean, default: true
+    settings.attribute :resources_permissions_enabled, type: :boolean, default: true
+    settings.attribute :dummy_global_attribute_1, type: :boolean
+    settings.attribute :dummy_global_attribute_2, type: :boolean, readonly: ->(_context) { false }
+    settings.attribute :readonly_attribute, type: :boolean, default: true, readonly: ->(_context) { true }
+    settings.attribute :enable_pads_creation, type: :boolean, default: false
+    settings.attribute :amendments_enabled, type: :boolean, default: false
+    settings.attribute :dummy_global_translatable_text, type: :text, translated: true, editor: true, required: true
+  end
+
+  component.settings(:step) do |settings|
+    settings.attribute :comments_blocked, type: :boolean, default: false
+    settings.attribute :dummy_step_attribute_1, type: :boolean
+    settings.attribute :dummy_step_attribute_2, type: :boolean, readonly: ->(_context) { false }
+    settings.attribute :dummy_step_translatable_text, type: :text, translated: true, editor: true, required: true
+    settings.attribute :readonly_step_attribute, type: :boolean, default: true, readonly: ->(_context) { true }
+    settings.attribute :amendment_creation_enabled, type: :boolean, default: true
+    settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
+    settings.attribute :amendment_promotion_enabled, type: :boolean, default: true
+    settings.attribute :amendments_visibility, type: :string, default: "all"
+    settings.attribute :endorsements_enabled, type: :boolean, default: false
+    settings.attribute :endorsements_blocked, type: :boolean, default: false
+  end
+
+  component.register_resource(:dummy_resource) do |resource|
+    resource.name = :dummy
+    resource.model_class_name = "Decidim::DummyResources::DummyResource"
+    resource.template = "decidim/dummy_resource/linked_dummys"
+    resource.actions = %w(foo)
+    resource.searchable = true
+  end
+
+  component.register_resource(:coauthorable_dummy_resource) do |resource|
+    resource.name = :coauthorable_dummy
+    resource.model_class_name = "Decidim::DummyResources::CoauthorableDummyResource"
+    resource.template = "decidim/coauthorabledummy_resource/linked_dummys"
+    resource.actions = %w(foo-coauthorable)
+    resource.searchable = false
+  end
+
+  component.register_stat :dummies_count_high, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|
+    components.count * 10
+  end
+
+  component.register_stat :dummies_count_medium, primary: true, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, _start_at, _end_at|
+    components.count * 100
+  end
+
+  component.exports :dummies do |exports|
+    exports.collection do
+      [1, 2, 3]
+    end
+
+    exports.serializer DummySerializer
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveRecord::Migration.suppress_messages do
+      unless ActiveRecord::Base.connection.data_source_exists?("decidim_dummy_resources_dummy_resources")
+        ActiveRecord::Migration.create_table :decidim_dummy_resources_dummy_resources do |t|
+          t.jsonb :translatable_text
+          t.string :title
+          t.string :body
+          t.text :address
+          t.float :latitude
+          t.float :longitude
+          t.datetime :published_at
+          t.integer :coauthorships_count, null: false, default: 0
+          t.integer :endorsements_count, null: false, default: 0
+
+          t.references :decidim_component, index: false
+          t.integer :decidim_author_id, index: false
+          t.string :decidim_author_type, index: false
+          t.integer :decidim_user_group_id, index: false
+          t.references :decidim_category, index: false
+          t.references :decidim_scope, index: false
+          t.string :reference
+
+          t.timestamps
+        end
+      end
+
+      unless ActiveRecord::Base.connection.data_source_exists?("decidim_dummy_resources_coauthorable_dummy_resources")
+        ActiveRecord::Migration.create_table :decidim_dummy_resources_coauthorable_dummy_resources do |t|
+          t.jsonb :translatable_text
+          t.string :title
+          t.string :body
+          t.text :address
+          t.float :latitude
+          t.float :longitude
+          t.datetime :published_at
+          t.integer :coauthorships_count, null: false, default: 0
+          t.integer :endorsements_count, null: false, default: 0
+
+          t.references :decidim_component, index: false
+          t.references :decidim_category, index: false
+          t.references :decidim_scope, index: false
+          t.string :reference
+
+          t.timestamps
+        end
+      end
+    end
+  end
+
+  config.before do
+    Decidim.find_component_manifest(:dummy).reset_hooks!
+  end
+end

--- a/lib/decidim/exporters/csv.rb
+++ b/lib/decidim/exporters/csv.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Decidim
+  module Exporters
+    # Exports any serialized object (Hash) into a readable CSV. It transforms
+    # the columns using slashes in a way that can be afterwards reconstructed
+    # into the original nested hash.
+    #
+    # For example, `{ name: { ca: "Hola", en: "Hello" } }` would result into
+    # the columns: `name/ca` and `name/es`.
+    class CSV < Exporter
+      # Public: Exports a CSV serialized version of the collection using the
+      # provided serializer and following the previously described strategy.
+      #
+      # Returns an ExportData instance.
+      def export(col_sep = Decidim.default_csv_col_sep)
+        data = ::CSV.generate(headers: headers, write_headers: true, col_sep: col_sep) do |csv|
+          processed_collection.each do |resource|
+            csv << headers.map { |header| resource[header] }
+          end
+        end
+        ExportData.new(data, "csv")
+      end
+
+      private
+
+      def headers
+        return [] if processed_collection.empty?
+
+        processed_collection.first.keys
+      end
+
+      def processed_collection
+        @processed_collection ||= collection.map do |resource|
+          flatten(@serializer.new(resource, @private_scope).serialize)
+        end
+      end
+
+      def flatten(object, key = nil)
+        if object.is_a? Hash
+          object.inject({}) do |result, (subkey, value)|
+            new_key = key ? "#{key}/#{subkey}" : subkey.to_s
+            result.merge(flatten(value, new_key))
+          end
+        elsif object.is_a?(Array)
+          { key.to_s => object.compact.map(&:to_s).join(", ") }
+        else
+          { key.to_s => object }
+        end
+      end
+    end
+  end
+end

--- a/lib/decidim/exporters/exporter.rb
+++ b/lib/decidim/exporters/exporter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Exporters
+    # Abstract class providing the interface and partial implementation
+    # of an exporter. See `Decidim::Exporters::JSON` and `Decidim::Exporters::CSV`
+    # for a reference implementation.
+    class Exporter
+      # Public: Initializes an Exporter.
+      #
+      # collection - An Array with the collection to be exported.
+      # serializer - A Serializer to be used during the export.
+      # private_scope - A boolean to manage admin_extra_fields export. By default, it doesn't exports admin_extra_fields
+      def initialize(collection, serializer = Serializer, private_scope = false)
+        @collection = collection
+        @serializer = serializer
+        @private_scope = private_scope
+      end
+
+      # Public: Should generate an `ExportData` with the result of the export.
+      # Responsibility of the subclass.
+      def export
+        raise NotImplementedError
+      end
+
+      private
+
+      attr_reader :collection, :serializer, :private_scope
+    end
+  end
+end

--- a/lib/decidim/exporters/json.rb
+++ b/lib/decidim/exporters/json.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Decidim
+  module Exporters
+    # Exports a JSON version of a provided hash, given a collection and a
+    # Serializer.
+    class JSON < Exporter
+      # Public: Generates a JSON representation of a collection and a
+      # Serializer.
+      #
+      # Returns an ExportData with the export.
+      def export
+        data = ::JSON.pretty_generate(@collection.map do |resource|
+          @serializer.new(resource, @private_scope).serialize
+        end)
+
+        ExportData.new(data, "json")
+      end
+    end
+  end
+end

--- a/lib/decidim/forms/user_answers_serializer.rb
+++ b/lib/decidim/forms/user_answers_serializer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Forms
+    # This class serializes the answers given by a User for questionnaire so can be
+    # exported to CSV, JSON or other formats.
+    class UserAnswersSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+
+      # Public: Initializes the serializer with a collection of Answers.
+      def initialize(answers, private_scope = false)
+        @answers = answers
+        @private_scope = private_scope
+      end
+
+      # Public: Exports a hash with the serialized data for the user answers.
+      def serialize
+        @answers.each_with_index.inject({}) do |serialized, (answer, idx)|
+          serialized.update(
+              answer_translated_attribute_name(:id) => answer.id,
+              answer_translated_attribute_name(:created_at) => answer.created_at.to_s(:db),
+              answer_translated_attribute_name(:ip_hash) => answer.ip_hash,
+              answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer.decidim_user_id.present? ? "registered" : "unregistered"),
+              "#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer)
+          )
+        end
+      end
+
+      private
+
+      def normalize_body(answer)
+        answer.body || normalize_choices(answer, answer.choices)
+      end
+
+      def normalize_choices(answer, choices)
+        if answer.question.matrix?
+          normalize_matrix_choices(answer, choices)
+        else
+          choices.map do |choice|
+            choice.try(:custom_body) || choice.try(:body)
+          end
+        end
+      end
+
+      def normalize_matrix_choices(answer, choices)
+        answer.question.matrix_rows.map do |matrix_row|
+          row_body = translated_attribute(matrix_row.body)
+
+          row_choices = answer.question.answer_options.map do |answer_option|
+            choice = choices.find_by(matrix_row: matrix_row, answer_option: answer_option)
+            choice.try(:custom_body) || choice.try(:body)
+          end
+
+          [row_body, row_choices]
+        end.to_h
+      end
+
+      def answer_translated_attribute_name(attribute)
+        I18n.t(attribute.to_sym, scope: "decidim.forms.user_answers_serializer")
+      end
+    end
+  end
+end

--- a/lib/decidim/greenpeace_overload/engine.rb
+++ b/lib/decidim/greenpeace_overload/engine.rb
@@ -18,6 +18,15 @@ module Decidim
       initializer "decidim_greenpeace_overload.assets" do |app|
         app.config.assets.precompile += %w[decidim_greenpeace_overload_manifest.js decidim_greenpeace_overload_manifest.css]
       end
+
+      initializer "decidim_greenpeace_overload.overrides" do
+        require 'decidim/comments/comment_serializer'
+        require 'decidim/proposals/proposal_serializer'
+        require 'decidim/meetings/meeting_serializer'
+        require 'decidim/exporters/csv'
+        require 'decidim/exporters/json'
+        require 'decidim/exporters/exporter'
+      end
     end
   end
 end

--- a/lib/decidim/greenpeace_overload/test/factories.rb
+++ b/lib/decidim/greenpeace_overload/test/factories.rb
@@ -2,11 +2,13 @@
 
 require "decidim/core/test/factories"
 require "decidim/proposals/test/factories"
+require "decidim/comments/test/factories"
+require "decidim/accountability/test/factories"
 
 FactoryBot.define do
   factory :greenpeace_overload_component, parent: :component do
     name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :greenpeace_overload).i18n_name }
-    manifest_name :greenpeace_overload
+    manifest_name { :greenpeace_overload }
     participatory_space { create(:participatory_process, :with_steps) }
   end
 

--- a/lib/decidim/greenpeace_overload/test/factories.rb
+++ b/lib/decidim/greenpeace_overload/test/factories.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/proposals/test/factories"
 
 FactoryBot.define do
   factory :greenpeace_overload_component, parent: :component do

--- a/lib/decidim/meetings/meeting_serializer.rb
+++ b/lib/decidim/meetings/meeting_serializer.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This class serializes a Meeting so can be exported to CSV, JSON or other
+    # formats.
+    class MeetingSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceHelper
+
+      # Public: Initializes the serializer with a meeting.
+      def initialize(meeting, private_scope = false)
+        @meeting = meeting
+        @private_scope = private_scope
+      end
+
+      # Public: Exports a hash with the serialized data for this meeting.
+      def serialize
+        {
+            id: meeting.id,
+            category: {
+                id: meeting.category.try(:id),
+                name: meeting.category.try(:name)
+            },
+            scope: {
+                id: meeting.scope.try(:id),
+                name: meeting.scope.try(:name)
+            },
+            participatory_space: {
+                id: meeting.participatory_space.id,
+                url: Decidim::ResourceLocatorPresenter.new(meeting.participatory_space).url
+            },
+            component: { id: component.id },
+            title: meeting.title,
+            description: meeting.description,
+            start_time: meeting.start_time.to_s(:db),
+            end_time: meeting.end_time.to_s(:db),
+            attendees: meeting.attendees_count.to_i,
+            contributions: meeting.contributions_count.to_i,
+            organizations: meeting.attending_organizations,
+            address: meeting.address,
+            location: meeting.location,
+            reference: meeting.reference,
+            comments: meeting.comments.count,
+            attachments: meeting.attachments.count,
+            followers: meeting.followers.count,
+            url: url,
+            related_proposals: related_proposals,
+            related_results: related_results
+        }
+      end
+
+      private
+
+      attr_reader :meeting
+
+      def component
+        meeting.component
+      end
+
+      def related_proposals
+        meeting.linked_resources(:proposals, "proposals_from_meeting").map do |proposal|
+          Decidim::ResourceLocatorPresenter.new(proposal).url
+        end
+      end
+
+      def related_results
+        meeting.linked_resources(:results, "meetings_through_proposals").map do |result|
+          Decidim::ResourceLocatorPresenter.new(result).url
+        end
+      end
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(meeting).url
+      end
+    end
+  end
+end

--- a/lib/decidim/proposals/proposal_serializer.rb
+++ b/lib/decidim/proposals/proposal_serializer.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # This class serializes a Proposal so can be exported to CSV, JSON or other
+    # formats.
+    class ProposalSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
+
+      # Public: Initializes the serializer with a proposal.
+      def initialize(proposal, private_scope = false)
+        @proposal = proposal
+        @private_scope = private_scope
+      end
+
+      # Public: Exports a hash with the serialized data for this proposal.
+      def serialize
+        {
+            id: proposal.id,
+            category: {
+                id: proposal.category.try(:id),
+                name: proposal.category.try(:name) || empty_translatable
+            },
+            scope: {
+                id: proposal.scope.try(:id),
+                name: proposal.scope.try(:name) || empty_translatable
+            },
+            participatory_space: {
+                id: proposal.participatory_space.id,
+                url: Decidim::ResourceLocatorPresenter.new(proposal.participatory_space).url
+            },
+            component: { id: component.id },
+            title: present(proposal).title,
+            body: present(proposal).body,
+            state: proposal.state.to_s,
+            reference: proposal.reference,
+            answer: ensure_translatable(proposal.answer),
+            supports: proposal.proposal_votes_count,
+            endorsements: {
+                total_count: proposal.endorsements.count,
+                user_endorsements: user_endorsements
+            },
+            comments: proposal.comments.count,
+            attachments: proposal.attachments.count,
+            followers: proposal.followers.count,
+            published_at: proposal.published_at,
+            url: url,
+            meeting_urls: meetings,
+            related_proposals: related_proposals,
+            is_amend: proposal.emendation?,
+            original_proposal: {
+                title: proposal&.amendable&.title,
+                url: original_proposal_url
+            }
+        }.merge(options_merge(admin_extra_fields))
+      end
+
+      private
+
+      attr_reader :proposal
+
+      def component
+        proposal.component
+      end
+
+      def meetings
+        proposal.linked_resources(:meetings, "proposals_from_meeting").map do |meeting|
+          Decidim::ResourceLocatorPresenter.new(meeting).url
+        end
+      end
+
+      def related_proposals
+        proposal.linked_resources(:proposals, "copied_from_component").map do |proposal|
+          Decidim::ResourceLocatorPresenter.new(proposal).url
+        end
+      end
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(proposal).url
+      end
+
+      def user_endorsements
+        proposal.endorsements.for_listing.map { |identity| identity.normalized_author&.name }
+      end
+
+      def original_proposal_url
+        return unless proposal.emendation? && proposal.amendable.present?
+
+        Decidim::ResourceLocatorPresenter.new(proposal.amendable).url
+      end
+
+      # Private: Returns a Hash with additional fields that administrator want to see in export
+      #
+      # Returns a Hash
+      def admin_extra_fields
+        {
+            author: {
+                id: proposal.creator_author[:id] || "",
+                age_slice: extended_data_key(proposal.creator_author, "age_slice"),
+                group_membership: extended_data_key(proposal.creator_author, "group_membership"),
+                question_racialized: extended_data_key(proposal.creator_author, "question_racialized"),
+                question_gender: extended_data_key(proposal.creator_author, "question_gender"),
+                question_sexual_orientation: extended_data_key(proposal.creator_author, "question_sexual_orientation"),
+                question_disability: extended_data_key(proposal.creator_author, "question_disability"),
+                question_social_context: extended_data_key(proposal.creator_author, "question_social_context")
+            }
+        }
+      end
+
+      def extended_data_key(user, key)
+        return "" if user.try(:extended_data).blank?
+        return "" if user[:extended_data].fetch(key, nil).blank?
+
+        user[:extended_data][key]
+      end
+    end
+  end
+end

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ExportJob do
+      # TODO: FIND A WAY TO OVERRIDE DUMMYSERIALIZER DEFINITION IN : /lib/decidim/dev/test/rspec_support/component.rb
+      let!(:component) { create(:component, manifest_name: "dummy") }
+      let(:organization) { component.organization }
+      let!(:user) { create(:user, organization: organization) }
+
+      it "sends an email with the result of the export" do
+        ExportJob.perform_now(user, component, "dummies", "CSV")
+
+        email = last_email
+        expect(email.subject).to include("dummies")
+        attachment = email.attachments.first
+
+        expect(attachment.read.length).to be_positive
+        expect(attachment.mime_type).to eq("application/zip")
+        expect(attachment.filename).to match(/^dummies-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+      end
+
+      describe "CSV" do
+        it "uses the CSV exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, DummySerializer, user.admin?))
+              .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+              .to(receive(:export).with(user, anything, export_data))
+              .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "dummies", "CSV")
+        end
+      end
+
+      describe "JSON" do
+        it "uses the JSON exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::JSON)
+              .to(receive(:new).with(anything, DummySerializer, user.admin?))
+              .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+              .to(receive(:export).with(user, anything, export_data))
+              .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "dummies", "JSON")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/comments/comment_serializer_spec.rb
+++ b/spec/lib/decidim/comments/comment_serializer_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Comments
+    describe CommentSerializer do
+      let(:comment) { create(:comment) }
+      let(:subject) { described_class.new(comment) }
+
+      let(:age_slice) { "15-25" }
+      let(:group_membership) { %w(local_group employee) }
+      let(:question_racialized) { "answer_yes" }
+      let(:question_gender) { "answer_yes" }
+      let(:question_sexual_orientation) { "answer_yes" }
+      let(:question_disability) { "answer_yes" }
+      let(:question_social_context) { "answer_yes" }
+
+      describe "#serialize" do
+        before do
+          comment.author.update!(extended_data: {
+              age_slice: age_slice,
+              group_membership: group_membership,
+              question_racialized: question_racialized,
+              question_gender: question_gender,
+              question_sexual_orientation: question_sexual_orientation,
+              question_disability: question_disability,
+              question_social_context: question_social_context
+          })
+        end
+
+        it "includes the id" do
+          expect(subject.serialize).to include(id: comment.id)
+        end
+
+        it "includes the creation date" do
+          expect(subject.serialize).to include(created_at: comment.created_at)
+        end
+
+        it "includes the body" do
+          expect(subject.serialize).to include(body: comment.body)
+        end
+
+        it "includes the author" do
+          expect(subject.serialize[:author]).to(
+              include(id: comment.author.id, name: comment.author.name)
+          )
+        end
+
+        it "includes the alignment" do
+          expect(subject.serialize).to include(alignment: comment.alignment)
+        end
+
+        it "includes the depth" do
+          expect(subject.serialize).to include(alignment: comment.depth)
+        end
+
+        it "includes the root commentable's url" do
+          expect(subject.serialize[:root_commentable_url]).to match(/http/)
+        end
+
+
+        it "does not include extended data" do
+          expect(subject.serialize).not_to include(:extended_data)
+        end
+
+        context "when user is admin" do
+          subject do
+            described_class.new(comment, true)
+          end
+
+          it "serializes the extended data" do
+            expect(subject.serialize).to include(:extended_data)
+            expect(subject.serialize[:extended_data]).to include(age_slice: comment.author[:extended_data]["age_slice"],
+                                                   group_membership: comment.author[:extended_data]["group_membership"],
+                                                   question_racialized: comment.author[:extended_data]["question_racialized"],
+                                                   question_gender: comment.author[:extended_data]["question_gender"],
+                                                   question_sexual_orientation: comment.author[:extended_data]["question_sexual_orientation"],
+                                                   question_disability: comment.author[:extended_data]["question_disability"],
+                                                   question_social_context: comment.author[:extended_data]["question_social_context"]
+                                           )
+          end
+
+          context "when optional extended_data field is empty" do
+            let(:age_slice) { "" }
+            let(:question_sexual_orientation) { "" }
+
+            it "serializes the extended data" do
+              expect(subject.serialize).to include(:extended_data)
+              expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                                   group_membership: comment.author[:extended_data]["group_membership"],
+                                                                   question_racialized: comment.author[:extended_data]["question_racialized"],
+                                                                   question_gender: comment.author[:extended_data]["question_gender"],
+                                                                   question_sexual_orientation: "",
+                                                                   question_disability: comment.author[:extended_data]["question_disability"],
+                                                                   question_social_context: comment.author[:extended_data]["question_social_context"]
+                                                           )
+            end
+          end
+
+          context "when user does not have extended_data" do
+            before do
+              comment.author.update!(extended_data: "")
+            end
+
+            it "serializes the author and extended data" do
+              expect(subject.serialize).to include(:extended_data)
+              expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                     group_membership: "",
+                                                     question_racialized: "",
+                                                     question_gender: "",
+                                                     question_sexual_orientation: "",
+                                                     question_disability: "",
+                                                     question_social_context: ""
+                                             )
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lib/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/lib/decidim/proposals/proposal_serializer_spec.rb
@@ -20,6 +20,13 @@ module Decidim
 
       let!(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
       let(:other_proposals) { create_list(:proposal, 2, component: proposals_component) }
+      let(:age_slice) { "15-25" }
+      let(:group_membership) { %w(local_group employee) }
+      let(:question_racialized) { "answer_yes" }
+      let(:question_gender) { "answer_yes" }
+      let(:question_sexual_orientation) { "answer_yes" }
+      let(:question_disability) { "answer_yes" }
+      let(:question_social_context) { "answer_yes" }
 
       let(:expected_answer) do
         answer = proposal.answer
@@ -35,6 +42,15 @@ module Decidim
       before do
         proposal.update!(category: category)
         proposal.update!(scope: scope)
+        proposal.creator_author.update!(extended_data: {
+            age_slice: age_slice,
+            group_membership: group_membership,
+            question_racialized: question_racialized,
+            question_gender: question_gender,
+            question_sexual_orientation: question_sexual_orientation,
+            question_disability: question_disability,
+            question_social_context: question_social_context
+        })
         proposal.link_resources(meetings, "proposals_from_meeting")
         proposal.link_resources(other_proposals, "copied_from_component")
       end
@@ -137,17 +153,46 @@ module Decidim
           end
         end
 
-        it "serializes the author and extended data" do
-          expect(serialized).to include(:author)
-          expect(serialized[:author]).to include(id: proposal&.creator_author&.id)
-          expect(serialized[:author][:extended_date]).to include(age_slice: proposal&.creator_author.extended_data[:age_slice],
-                                                                group_membership: proposal&.creator_author.extended_data[:group_membership],
-                                                                question_racialized: proposal&.creator_author.extended_data[:question_racialized],
-                                                                question_gender: proposal&.creator_author.extended_data[:question_gender],
-                                                                question_sexual_orientation: proposal&.creator_author.extended_data[:question_sexual_orientation],
-                                                                question_disability: proposal&.creator_author.extended_data[:question_disability],
-                                                                question_social_context: proposal&.creator_author.extended_data[:question_social_context]
-                                                         )
+        it "doest not serializes the author" do
+          expect(serialized).not_to include(:author)
+        end
+
+        context "when user is admin" do
+          subject do
+            described_class.new(proposal, true)
+          end
+
+          it "serializes the author and extended data" do
+            expect(serialized).to include(:author)
+            expect(serialized[:author]).to include(id: proposal&.creator_author&.id)
+            expect(serialized[:author]).to include(age_slice: proposal&.creator_author[:extended_data]["age_slice"],
+                                                                   group_membership: proposal&.creator_author[:extended_data]["group_membership"],
+                                                                   question_racialized: proposal&.creator_author[:extended_data]["question_racialized"],
+                                                                   question_gender: proposal&.creator_author[:extended_data]["question_gender"],
+                                                                   question_sexual_orientation: proposal&.creator_author[:extended_data]["question_sexual_orientation"],
+                                                                   question_disability: proposal&.creator_author[:extended_data]["question_disability"],
+                                                                   question_social_context: proposal&.creator_author[:extended_data]["question_social_context"]
+                                                           )
+          end
+
+          context "when user does not have extended_data" do
+            before do
+              proposal.creator_author.update!(extended_data: "")
+            end
+
+            it "serializes the author and extended data" do
+              expect(serialized).to include(:author)
+              expect(serialized[:author]).to include(id: proposal&.creator_author&.id)
+              expect(serialized[:author]).to include(age_slice: "",
+                                                     group_membership: "",
+                                                     question_racialized: "",
+                                                     question_gender: "",
+                                                     question_sexual_orientation: "",
+                                                     question_disability: "",
+                                                     question_social_context: ""
+                                             )
+            end
+          end
         end
       end
     end

--- a/spec/lib/exporters/csv_spec.rb
+++ b/spec/lib/exporters/csv_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "csv"
+
+module Decidim
+  describe Exporters::CSV do
+    subject { described_class.new(collection, serializer) }
+
+    let(:serializer) do
+      Class.new do
+        def initialize(resource, private_scope = false)
+          @resource = resource
+          @private_scope = private_scope
+        end
+
+        def serialize
+          {
+              id: @resource.id,
+              serialized_name: @resource.name,
+              other_ids: @resource.ids
+          }
+        end
+      end
+    end
+
+    let(:collection) do
+      [
+          OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3]),
+          OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [1, 2, 3])
+      ]
+    end
+
+    describe "export" do
+      it "exports the collection using the right serializer" do
+        exported = subject.export.read
+        data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
+        expect(data[0]["serialized_name/ca"]).to eq("foocat")
+      end
+    end
+  end
+end

--- a/spec/lib/exporters/excel_spec.rb
+++ b/spec/lib/exporters/excel_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "spreadsheet"
+
+module Decidim
+  describe Exporters::Excel do
+    subject { described_class.new(collection, serializer) }
+
+    let(:serializer) do
+      Class.new do
+        def initialize(resource, private_scope = false)
+          @resource = resource
+          @private_scope = private_scope
+        end
+
+        def serialize
+          {
+              id: @resource.id,
+              serialized_name: @resource.name,
+              other_ids: @resource.ids,
+              float: @resource.float,
+              date: @resource.date
+          }
+        end
+      end
+    end
+
+    let(:collection) do
+      [
+          OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3], float: 1.66, date: Time.zone.local(2017, 10, 1, 5, 0)),
+          OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: Time.zone.local(2017, 9, 20))
+      ]
+    end
+
+    describe "export" do
+      it "exports the collection using the right serializer" do
+        exported = StringIO.new(subject.export.read)
+        book = Spreadsheet.open(exported)
+        worksheet = book.worksheet(0)
+        expect(worksheet.rows.length).to eq(3)
+
+        headers = worksheet.rows[0]
+        expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
+        expect(worksheet.rows[1][0..4]).to eq([1, "foocat", "fooes", "1, 2, 3", 1.66])
+        expect(worksheet.rows[1].datetime(5)).to eq(Time.zone.local(2017, 10, 1, 5, 0))
+
+        expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
+        expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
+      end
+    end
+  end
+end

--- a/spec/lib/exporters/json_spec.rb
+++ b/spec/lib/exporters/json_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters::JSON do
+    subject { described_class.new(collection, serializer) }
+
+    let(:serializer) do
+      Class.new do
+        def initialize(resource, private_scope = false)
+          @resource = resource
+          @private_scope = private_scope
+        end
+
+        def serialize
+          {
+              id: @resource.id,
+              serialized_name: @resource.name
+          }
+        end
+      end
+    end
+
+    let(:collection) do
+      [OpenStruct.new(id: 1, name: "foo"), OpenStruct.new(id: 2, name: "bar")]
+    end
+
+    describe "export" do
+      it "exports the collection using the right serializer" do
+        json = JSON.parse(subject.export.read)
+        expect(json[0]).to eq("id" => 1, "serialized_name" => "foo")
+        expect(json[1]).to eq("id" => 2, "serialized_name" => "bar")
+      end
+    end
+  end
+end

--- a/spec/serializers/data_portability_registration_serializer_spec.rb
+++ b/spec/serializers/data_portability_registration_serializer_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe DataPortabilityRegistrationSerializer do
+    let(:resource) { create(:registration) }
+    let(:subject) { described_class.new(resource) }
+
+    let(:age_slice) { "15-25" }
+    let(:group_membership) { %w(local_group employee) }
+    let(:question_racialized) { "answer_yes" }
+    let(:question_gender) { "answer_yes" }
+    let(:question_sexual_orientation) { "answer_yes" }
+    let(:question_disability) { "answer_yes" }
+    let(:question_social_context) { "answer_yes" }
+
+    describe "#serialize" do
+      before do
+        resource.user.update!(extended_data: {
+            age_slice: age_slice,
+            group_membership: group_membership,
+            question_racialized: question_racialized,
+            question_gender: question_gender,
+            question_sexual_orientation: question_sexual_orientation,
+            question_disability: question_disability,
+            question_social_context: question_social_context
+        })
+      end
+      it "includes the id" do
+        expect(subject.serialize).to include(id: resource.id)
+      end
+
+      it "includes the registration code" do
+        expect(subject.serialize).to include(code: resource.code)
+      end
+
+      it "includes the user" do
+        expect(subject.serialize[:user]).to(
+            include(name: resource.user.name)
+        )
+        expect(subject.serialize[:user]).to(
+            include(email: resource.user.email)
+        )
+      end
+
+      it "includes the meeting" do
+        expect(subject.serialize[:meeting]).to(
+            include(title: resource.meeting.title)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(description: resource.meeting.description)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(start_time: resource.meeting.start_time)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(end_time: resource.meeting.end_time)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(address: resource.meeting.address)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(location: resource.meeting.location)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(location_hints: resource.meeting.location_hints)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(reference: resource.meeting.reference)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(attendees_count: resource.meeting.attendees_count)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(attending_organizations: resource.meeting.attending_organizations)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(closed_at: resource.meeting.closed_at)
+        )
+
+        expect(subject.serialize[:meeting]).to(
+            include(closing_report: resource.meeting.closing_report)
+        )
+      end
+
+      context "when user is admin" do
+        subject do
+          described_class.new(resource, true)
+        end
+
+        it "serializes the extended data" do
+          expect(subject.serialize).to include(:extended_data)
+          expect(subject.serialize[:extended_data]).to include(age_slice: resource.user[:extended_data]["age_slice"],
+                                                               group_membership: resource.user[:extended_data]["group_membership"],
+                                                               question_racialized: resource.user[:extended_data]["question_racialized"],
+                                                               question_gender: resource.user[:extended_data]["question_gender"],
+                                                               question_sexual_orientation: resource.user[:extended_data]["question_sexual_orientation"],
+                                                               question_disability: resource.user[:extended_data]["question_disability"],
+                                                               question_social_context: resource.user[:extended_data]["question_social_context"]
+                                                       )
+        end
+
+        context "when optional extended_data field is empty" do
+          let(:age_slice) { "" }
+          let(:question_sexual_orientation) { "" }
+
+          it "serializes the extended data" do
+            expect(subject.serialize).to include(:extended_data)
+            expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                                 group_membership: resource.user[:extended_data]["group_membership"],
+                                                                 question_racialized: resource.user[:extended_data]["question_racialized"],
+                                                                 question_gender: resource.user[:extended_data]["question_gender"],
+                                                                 question_sexual_orientation: "",
+                                                                 question_disability: resource.user[:extended_data]["question_disability"],
+                                                                 question_social_context: resource.user[:extended_data]["question_social_context"]
+                                                         )
+          end
+        end
+
+        context "when user does not have extended_data" do
+          before do
+            resource.user.update!(extended_data: "")
+          end
+
+          it "serializes the author and extended data" do
+            expect(subject.serialize).to include(:extended_data)
+            expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                                 group_membership: "",
+                                                                 question_racialized: "",
+                                                                 question_gender: "",
+                                                                 question_sexual_orientation: "",
+                                                                 question_disability: "",
+                                                                 question_social_context: ""
+                                                         )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/decidim/exporters/serializer_spec.rb
+++ b/spec/serializers/decidim/exporters/serializer_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  #TODO: UPDATE TEST
+  describe Exporters::Serializer do
+    let(:subject) { described_class.new(resource) }
+    let(:resource) { OpenStruct.new(id: 1, name: "John") }
+    let(:admin_extra_fields) { OpenStruct.new(age: 30, city: "London") }
+
+    it { expect(subject).respond_to? :resource }
+
+    describe "#serialize" do
+      context "when export is public" do
+        it "serializer doesn't merge the admin_extra_fields" do
+          expect(subject.serialize).to include(:id)
+          expect(subject.serialize).to include(:name)
+          expect(subject.serialize).not_to include(:age)
+          expect(subject.serialize).not_to include(:city)
+        end
+
+        it "turns the object into a hash" do
+          expect(subject.serialize).to eq(id: resource.id, name: resource.name)
+        end
+      end
+
+      context "when export is made by administrator" do
+        let(:subject) { described_class.new(resource, true) }
+
+        before do
+          allow(subject).to receive(:admin_extra_fields).and_return(admin_extra_fields.to_h)
+        end
+
+        it "serializer merges the admin_extra_fields" do
+          expect(subject.serialize).to include(:id)
+          expect(subject.serialize).to include(:name)
+          expect(subject.serialize).to include(:age)
+          expect(subject.serialize).to include(:city)
+        end
+
+        it "turns the object into a hash" do
+          expect(subject.serialize).to eq(
+                                           id: resource.id,
+                                           name: resource.name,
+                                           age: admin_extra_fields.age,
+                                           city: admin_extra_fields.city
+                                       )
+        end
+      end
+    end
+
+    describe "#options_merge" do
+      context "when export is public" do
+        it "returns a empty Hash" do
+          expect(subject.send(:options_merge, admin_extra_fields.to_h)).to eq({})
+        end
+      end
+
+      context "when export is made by administrator" do
+        let(:subject) { described_class.new(resource, true) }
+
+        it "returns the options parameter" do
+          expect(subject.send(:options_merge, admin_extra_fields.to_h)).to eq(age: admin_extra_fields.age, city: admin_extra_fields.city)
+        end
+
+        context "when options parameters is empty" do
+          it "returns a empty hash" do
+            expect(subject.send(:options_merge)).to eq({})
+          end
+        end
+
+        context "when options parameters is not a Hash" do
+          it "returns a empty hash" do
+            expect(subject.send(:options_merge, admin_extra_fields)).to eq({})
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/decidim/exporters/serializer_spec.rb
+++ b/spec/serializers/decidim/exporters/serializer_spec.rb
@@ -3,7 +3,6 @@
 require "spec_helper"
 
 module Decidim
-  #TODO: UPDATE TEST
   describe Exporters::Serializer do
     let(:subject) { described_class.new(resource) }
     let(:resource) { OpenStruct.new(id: 1, name: "John") }

--- a/spec/serializers/registration_serializer_spec.rb
+++ b/spec/serializers/registration_serializer_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  shared_examples "extended_data for admin user" do
+    context "when user is admin" do
+      subject do
+        described_class.new(registration, true)
+      end
+
+      it "serializes the extended data" do
+        expect(subject.serialize).to include(:extended_data)
+        expect(subject.serialize[:extended_data]).to include(age_slice: registration.user[:extended_data]["age_slice"],
+                                                             group_membership: registration.user[:extended_data]["group_membership"],
+                                                             question_racialized: registration.user[:extended_data]["question_racialized"],
+                                                             question_gender: registration.user[:extended_data]["question_gender"],
+                                                             question_sexual_orientation: registration.user[:extended_data]["question_sexual_orientation"],
+                                                             question_disability: registration.user[:extended_data]["question_disability"],
+                                                             question_social_context: registration.user[:extended_data]["question_social_context"]
+                                                     )
+      end
+
+      context "when optional extended_data field is empty" do
+        let(:age_slice) { "" }
+        let(:question_sexual_orientation) { "" }
+
+        it "serializes the extended data" do
+          expect(subject.serialize).to include(:extended_data)
+          expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                               group_membership: registration.user[:extended_data]["group_membership"],
+                                                               question_racialized: registration.user[:extended_data]["question_racialized"],
+                                                               question_gender: registration.user[:extended_data]["question_gender"],
+                                                               question_sexual_orientation: "",
+                                                               question_disability: registration.user[:extended_data]["question_disability"],
+                                                               question_social_context: registration.user[:extended_data]["question_social_context"]
+                                                       )
+        end
+      end
+
+      context "when user does not have extended_data" do
+        before do
+          registration.user.update!(extended_data: "")
+        end
+
+        it "serializes the author and extended data" do
+          expect(subject.serialize).to include(:extended_data)
+          expect(subject.serialize[:extended_data]).to include(age_slice: "",
+                                                 group_membership: "",
+                                                 question_racialized: "",
+                                                 question_gender: "",
+                                                 question_sexual_orientation: "",
+                                                 question_disability: "",
+                                                 question_social_context: ""
+                                         )
+        end
+      end
+    end
+
+  end
+  describe RegistrationSerializer do
+    describe "#serialize" do
+      let!(:registration) { create(:registration) }
+      let!(:subject) { described_class.new(registration) }
+      let(:age_slice) { "15-25" }
+      let(:group_membership) { %w(local_group employee) }
+      let(:question_racialized) { "answer_yes" }
+      let(:question_gender) { "answer_yes" }
+      let(:question_sexual_orientation) { "answer_yes" }
+      let(:question_disability) { "answer_yes" }
+      let(:question_social_context) { "answer_yes" }
+
+      before do
+        registration.user.update!(extended_data: {
+            age_slice: age_slice,
+            group_membership: group_membership,
+            question_racialized: question_racialized,
+            question_gender: question_gender,
+            question_sexual_orientation: question_sexual_orientation,
+            question_disability: question_disability,
+            question_social_context: question_social_context
+        })
+      end
+      context "when there are not a questionnaire" do
+        it "includes the id" do
+          expect(subject.serialize).to include(id: registration.id)
+        end
+
+        it "includes the registration code" do
+          expect(subject.serialize).to include(code: registration.code)
+        end
+
+        it "includes the user" do
+          expect(subject.serialize[:user]).to(
+              include(name: registration.user.name)
+          )
+          expect(subject.serialize[:user]).to(
+              include(email: registration.user.email)
+          )
+        end
+
+        it "does not include the extended_data" do
+          expect(subject.serialize).not_to include(:extended_data)
+        end
+
+        it_behaves_like "extended_data for admin user"
+      end
+
+      context "when questionaire enabled" do
+        let(:meeting) { create :meeting, :with_registrations_enabled }
+        let!(:user) { create(:user, organization: meeting.organization) }
+        let!(:registration) { create(:registration, meeting: meeting, user: user) }
+
+        let!(:questions) { create_list :questionnaire_question, 3, questionnaire: meeting.questionnaire }
+        let!(:answers) do
+          questions.map do |question|
+            create :answer, questionnaire: meeting.questionnaire, question: question, user: user
+          end
+        end
+
+        let!(:multichoice_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "multiple_option" }
+        let!(:multichoice_answer_options) { create_list :answer_option, 2, question: multichoice_question }
+        let!(:multichoice_answer) do
+          create :answer, questionnaire: meeting.questionnaire, question: multichoice_question, user: user, body: nil
+        end
+        let!(:multichoice_answer_choices) do
+          multichoice_answer_options.map do |answer_option|
+            create :answer_choice, answer: multichoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+          end
+        end
+
+        let!(:singlechoice_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "single_option" }
+        let!(:singlechoice_answer_options) { create_list :answer_option, 2, question: multichoice_question }
+        let!(:singlechoice_answer) do
+          create :answer, questionnaire: meeting.questionnaire, question: singlechoice_question, user: user, body: nil
+        end
+        let!(:singlechoice_answer_choice) do
+          answer_option = singlechoice_answer_options.first
+          create :answer_choice, answer: singlechoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+        end
+
+        let!(:subject) { described_class.new(registration) }
+        let(:serialized) { subject.serialize }
+
+        it "includes the answer for each question" do
+          expect(serialized[:registration_form_answers]).to include(
+                                                                "1. #{translated(questions.first.body, locale: I18n.locale)}" => answers.first.body
+                                                            )
+          expect(serialized[:registration_form_answers]).to include(
+                                                                "3. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
+                                                            )
+          expect(serialized[:registration_form_answers]).to include(
+                                                                "4. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+                                                            )
+
+          expect(serialized[:registration_form_answers]).to include(
+                                                                "5. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
+                                                            )
+        end
+
+        it "does not include the extended_data" do
+          expect(subject.serialize).not_to include(:extended_data)
+        end
+
+        it_behaves_like "extended_data for admin user"
+      end
+    end
+  end
+end

--- a/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalSerializer do
+      subject do
+        described_class.new(proposal)
+      end
+
+      let!(:proposal) { create(:proposal, :accepted) }
+      let!(:category) { create(:category, participatory_space: component.participatory_space) }
+      let!(:scope) { create(:scope, organization: component.participatory_space.organization) }
+      let(:participatory_process) { component.participatory_space }
+      let(:component) { proposal.component }
+
+      let!(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
+      let(:meetings) { create_list(:meeting, 2, component: meetings_component) }
+
+      let!(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
+      let(:other_proposals) { create_list(:proposal, 2, component: proposals_component) }
+
+      let(:expected_answer) do
+        answer = proposal.answer
+        Decidim.available_locales.each_with_object({}) do |locale, result|
+          result[locale.to_s] = if answer.is_a?(Hash)
+                                  answer[locale.to_s] || ""
+                                else
+                                  ""
+                                end
+        end
+      end
+
+      before do
+        proposal.update!(category: category)
+        proposal.update!(scope: scope)
+        proposal.link_resources(meetings, "proposals_from_meeting")
+        proposal.link_resources(other_proposals, "copied_from_component")
+      end
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "serializes the id" do
+          expect(serialized).to include(id: proposal.id)
+        end
+
+        it "serializes the category" do
+          expect(serialized[:category]).to include(id: category.id)
+          expect(serialized[:category]).to include(name: category.name)
+        end
+
+        it "serializes the scope" do
+          expect(serialized[:scope]).to include(id: scope.id)
+          expect(serialized[:scope]).to include(name: scope.name)
+        end
+
+        it "serializes the title" do
+          expect(serialized).to include(title: proposal.title)
+        end
+
+        it "serializes the body" do
+          expect(serialized).to include(body: proposal.body)
+        end
+
+        it "serializes the amount of supports" do
+          expect(serialized).to include(supports: proposal.proposal_votes_count)
+        end
+
+        it "serializes the amount of comments" do
+          expect(serialized).to include(comments: proposal.comments.count)
+        end
+
+        it "serializes the date of creation" do
+          expect(serialized).to include(published_at: proposal.published_at)
+        end
+
+        it "serializes the url" do
+          expect(serialized[:url]).to include("http", proposal.id.to_s)
+        end
+
+        it "serializes the component" do
+          expect(serialized[:component]).to include(id: proposal.component.id)
+        end
+
+        it "serializes the meetings" do
+          expect(serialized[:meeting_urls].length).to eq(2)
+          expect(serialized[:meeting_urls].first).to match(%r{http.*/meetings})
+        end
+
+        it "serializes the participatory space" do
+          expect(serialized[:participatory_space]).to include(id: participatory_process.id)
+          expect(serialized[:participatory_space][:url]).to include("http", participatory_process.slug)
+        end
+
+        it "serializes the state" do
+          expect(serialized).to include(state: proposal.state)
+        end
+
+        it "serializes the reference" do
+          expect(serialized).to include(reference: proposal.reference)
+        end
+
+        it "serializes the answer" do
+          expect(serialized).to include(answer: expected_answer)
+        end
+
+        it "serializes the amount of attachments" do
+          expect(serialized).to include(attachments: proposal.attachments.count)
+        end
+
+        it "serializes the endorsements" do
+          expect(serialized[:endorsements]).to include(total_count: proposal.endorsements.count)
+          expect(serialized[:endorsements]).to include(user_endorsements: proposal.endorsements.for_listing.map { |identity| identity.normalized_author&.name })
+        end
+
+        it "serializes related proposals" do
+          expect(serialized[:related_proposals].length).to eq(2)
+          expect(serialized[:related_proposals].first).to match(%r{http.*/proposals})
+        end
+
+        it "serializes if proposal is_amend" do
+          expect(serialized).to include(is_amend: proposal.emendation?)
+        end
+
+        it "serializes the original proposal" do
+          expect(serialized[:original_proposal]).to include(title: proposal&.amendable&.title)
+          expect(serialized[:original_proposal][:url]).to be_nil || include("http", proposal.id.to_s)
+        end
+
+        context "with proposal having an answer" do
+          let!(:proposal) { create(:proposal, :with_answer) }
+
+          it "serializes the answer" do
+            expect(serialized).to include(answer: expected_answer)
+          end
+        end
+
+        it "serializes the author and extended data" do
+          expect(serialized).to include(:author)
+          expect(serialized[:author]).to include(id: proposal&.creator_author&.id)
+          expect(serialized[:author][:extended_date]).to include(age_slice: proposal&.creator_author.extended_data[:age_slice],
+                                                                group_membership: proposal&.creator_author.extended_data[:group_membership],
+                                                                question_racialized: proposal&.creator_author.extended_data[:question_racialized],
+                                                                question_gender: proposal&.creator_author.extended_data[:question_gender],
+                                                                question_sexual_orientation: proposal&.creator_author.extended_data[:question_sexual_orientation],
+                                                                question_disability: proposal&.creator_author.extended_data[:question_disability],
+                                                                question_social_context: proposal&.creator_author.extended_data[:question_social_context]
+                                                         )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What ? Why ?

Enable extra fields export for administrators only. Those fields are not exported with open data. 

## Tasks
- [x] Export optional fields in Proposals, Comments
- [x] Add tests
- [ ] Export optional fields in meetings
- [ ] Fix `spec/jobs/export_job_spec.rb` because of `lib/decidim/dev/test/rspec_support/component.rb` not loaded
- [ ] Override *every* Serializer that implements `initialize` with juste one argument (Allows to avoid ArgumentError https://github.com/OpenSourcePolitics/decidim/issues/1046) 
